### PR TITLE
Registration options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,10 +29,11 @@ async function start() {
     const { browser, context } = playwrightObjects;
     const trafficlightUrl = process.env.TRAFFICLIGHT_URL || "http://127.0.0.1:5000";
     const elementCallURL = process.env["BASE_APP_URL"] ?? trafficlightConfig["element-call-instance-url"];
+    const elementCallType = process.env["BASE_APP_TYPE"] ?? trafficlightConfig["element-call-instance-type"];
     const client = new ElementCallTrafficlightClient(trafficlightUrl, context, browser, elementCallURL);
     await addActionsToClient(client);
     console.log("\nThe following actions were found:\n", client.availableActions.join(", "));
-    await client.register();
+    await client.register(elementCallType);
     try {
         await client.newPage();
         const promise = client.start();

--- a/src/trafficlight/ElementCallTrafficlightClient.ts
+++ b/src/trafficlight/ElementCallTrafficlightClient.ts
@@ -25,9 +25,10 @@ export class ElementCallTrafficlightClient extends TrafficLightClient {
         super(trafficLightServerURL, context, browser);
     }
 
-    async register(): Promise<void> {
+    async register(version: string): Promise<void> {
         await super.doRegister("element-call", {
-            version: "UNKNOWN",
+            version: version,
+            url: self.elementCallURL
         });
     }
 

--- a/trafficlight.config.json
+++ b/trafficlight.config.json
@@ -1,3 +1,4 @@
 {
-    "element-call-instance-url": "http://localhost:4173"
+    "element-call-instance-url": "https://element-call.netlify.app",
+    "element-call-identifier": "staging"
 }


### PR DESCRIPTION
Pass a version (eg, staging, live) and URL to the registration request. Trafficlight currently will ignore these; but this opens up the ability to add ElementCallLive and ElementCallStaging to check cross-compatibility of the older and newer versions, for example.