### PR TITLE
Upload videos, also wait a little for camera to change images

### DIFF
--- a/src/actions/browser.ts
+++ b/src/actions/browser.ts
@@ -22,7 +22,6 @@ module.exports = {
     },
 
     "recreate": async ({ data, page, client }: {data: any, client: ElementCallTrafficlightClient, page: Page}) => {
-        // This currently does not work; the client.newPage() method does not update the `page` property of the client.
         if (data["unload_hooks"] == "False") {
             await page.close({ runBeforeUnload: false });
         } else {

--- a/src/actions/video.ts
+++ b/src/actions/video.ts
@@ -1,13 +1,17 @@
 
 import { copyFile } from "fs/promises";
 module.exports = {
-    "set_video_image": async ({data}) => {
+    "set_video_image": async ({data, page}) => {
         const image = data["image"];
-        // Manage two files here, so ffmpeg stats and reopens repeatedly, rather        // than when it uses a single file which it loads once.
+        // Manage two files here, so ffmpeg stats and reopens repeatedly, rather
+        // than when it uses a single file which it loads once.
 
         // TODO: investigate alternatives to this as it's a bit janky.
         await copyFile("video/images/" + image + ".png", "video/images/target0.png");
         await copyFile("video/images/" + image + ".png", "video/images/target1.png");
+
+        // We cycle every second; ensure we've finished cycling before we return
+        await page.waitForTimeout(1000);
         return "set_image_done";
     },
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ async function start() {
     catch (e) {
         console.error(e);
     } finally {
+        await client.uploadPageVideo();
         ffmpeg.kill();
     }
 }

--- a/src/trafficlight/ElementCallTrafficlightClient.ts
+++ b/src/trafficlight/ElementCallTrafficlightClient.ts
@@ -36,7 +36,15 @@ export class ElementCallTrafficlightClient extends TrafficLightClient {
         return this.actionMap.actions;
     }
 
+    async uploadPageVideo() {
+        const upload_name = `screencast_${this.offset}.webm`;
+        return this.uploadFile(await this.page.video().path(), upload_name);
+    }
+
     async newPage() {
+	if (this.page) {
+            await this.uploadPageVideo();
+        }
         const new_page = await this.context.newPage();
         const prefix = "PP"+(this.offset++)+": ";
         new_page.on("console", msg => console.log(prefix + msg.text()));

--- a/src/trafficlight/TrafficLightClient.ts
+++ b/src/trafficlight/TrafficLightClient.ts
@@ -142,22 +142,11 @@ export class TrafficLightClient {
                         const files = result["_upload_files"];
                         if (files) {
                             for (var file in files) {
-                                const formData = new FormData();
-                                const filestream = fs.createReadStream(file);
-                                formData.append("file", filestream, { contentType: "application/octet-stream", filename: file });
-                                const fileResponse = await fetch(this.uploadUrl, {
-                                    method: "POST",
-                                    body: formData
-                                });
-                                // At the moment we don't care if we fail to upload
-                                // as the trafficlight server will proceed to error out
-                                // afterwards because it doesn't have the files it needs.
-                                console.log(`Uploaded ${file} with response ${ fileResponse.status}`);
-
+                                // files is map filename -> path on disk
+                                await this.uploadFile(files[file], file);
                             }
                         }
                     }
-
                     
                     const respondResponse = await fetch(this.respondUrl, {
                         method: "POST",
@@ -202,4 +191,17 @@ export class TrafficLightClient {
         return `${this.clientBaseUrl}/respond`;
     }
 
+    async uploadFile(file: string, filename: string) {
+        const formData = new FormData();
+        const filestream = fs.createReadStream(file);
+        formData.append("file", filestream, { contentType: "application/octet-stream", filename: filename });
+        const fileResponse = await fetch(this.uploadUrl, {
+            method: "POST",
+            body: formData
+        });
+        // At the moment we don't care if we fail to upload
+        // as the trafficlight server will proceed to error out
+        // afterwards because it doesn't have the files it needs.
+        console.log(`Uploaded ${file} with response ${ fileResponse.status}`);
+    }
 }


### PR DESCRIPTION
This means we can see what live action video has happened without needing to mount the directory from the docker containers.