### PR TITLE
Video mute

### DIFF
--- a/src/actions/call.ts
+++ b/src/actions/call.ts
@@ -124,6 +124,29 @@ module.exports = {
         await page.getByTestId("incall_leave").click();
         return "left_call";
     },
+    
+    "set_video_mute": async({ page, data } : { page: Page , data: any}) => {
+        const videoIcon = page.getByTestId("incall_videomute");
+        const nestedSvg = page.locator("xpath=//svg/path");
+        const svg_fill = await videoIcon.locator(nestedSvg).first().getAttribute("fill");
+        let current_mute;
+	if (svg_fill == "white") {
+            current_mute = true;
+        } else if (svg_fill == "#394049") {
+            current_mute = false;
+        } else {
+            throw Exception("unable to determine mute-ness of the call");
+        }
+
+	if ((current_mute && data["video_mute"] == "false") || (
+	    !current_mute && data["video_mute"] == "true")) {
+            await page.getByTestId("incall_videomute").click();
+        }
+            else {
+                console.log("Video muted; leaving alone")
+            }
+       return { "response": "video_mute_toggled", "data": { "previously_muted": current_mute } };
+    },
 
     "start_screenshare": async ({ page }: { page: Page }) => {
        await page.getByTestId("incall_screenshare").click();

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ async function start() {
     const client = new ElementCallTrafficlightClient(trafficlightUrl, context, browser, elementCallURL);
     await addActionsToClient(client);
     console.log("\nThe following actions were found:\n", client.availableActions.join(", "));
-    await client.register(elementCallType);
+    await client.register(elementCallType, elementCallURL);
     try {
         await client.newPage();
         const promise = client.start();

--- a/src/trafficlight/ElementCallTrafficlightClient.ts
+++ b/src/trafficlight/ElementCallTrafficlightClient.ts
@@ -25,9 +25,10 @@ export class ElementCallTrafficlightClient extends TrafficLightClient {
         super(trafficLightServerURL, context, browser);
     }
 
-    async register(version: string): Promise<void> {
+    async register(version: string, url: string): Promise<void> {
         await super.doRegister("element-call", {
-            version: version
+            version: version,
+            url: url
         });
     }
 


### PR DESCRIPTION
This doesn't currently work as the element-call webapp is [not happy to mute the video if there's no audio](https://github.com/vector-im/element-call/issues/1072)

However, the logic is sound, and works if a video and audio device is available, so i think it's good to merge.